### PR TITLE
Use control colors to fit dark theme

### DIFF
--- a/MFCore/MFLogViewerTableCell.m
+++ b/MFCore/MFLogViewerTableCell.m
@@ -83,7 +83,7 @@
 	
 	NSMutableParagraphStyle *par = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
 	[par setLineBreakMode:NSLineBreakByCharWrapping];
-	NSColor* color = current && [self isHighlighted] ? [NSColor whiteColor] : [NSColor blackColor];
+	NSColor* color = current && [self isHighlighted] ? [NSColor selectedTextColor] : [NSColor textColor];
 	return [NSDictionary dictionaryWithObjectsAndKeys:color, NSForegroundColorAttributeName,
 			[NSFont systemFontOfSize:11.0], NSFontAttributeName,[par copy], NSParagraphStyleAttributeName,
 			nil];

--- a/Settings/MFFilesystemCell.m
+++ b/Settings/MFFilesystemCell.m
@@ -89,12 +89,12 @@
 	[style setLineBreakMode: NSLineBreakByTruncatingTail];
 	
 	NSMutableDictionary* mainTextAttributes = [NSMutableDictionary dictionaryWithObjectsAndKeys: 
-											   [NSColor blackColor], NSForegroundColorAttributeName,
+											   [NSColor controlTextColor], NSForegroundColorAttributeName,
 											   [NSFont systemFontOfSize:14], NSFontAttributeName,
 											   style, NSParagraphStyleAttributeName,
 											   nil];
 	NSMutableDictionary* secondaryTextAttributes = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-													[NSColor grayColor], NSForegroundColorAttributeName,
+													[NSColor controlTextColor], NSForegroundColorAttributeName,
 													[NSFont systemFontOfSize:12], NSFontAttributeName,
 													style, NSParagraphStyleAttributeName,
 													nil];
@@ -129,16 +129,23 @@
 
 	if ([self isHighlighted] && current)
 	{
-		[mainTextAttributes setValue: [NSColor whiteColor]
-							  forKey: NSForegroundColorAttributeName];
-		[secondaryTextAttributes setValue: [NSColor whiteColor]
-								   forKey: NSForegroundColorAttributeName];
+		if (@available(macOS 10.12, *)) {
+			[mainTextAttributes setValue: [NSColor alternateSelectedControlTextColor]
+								  forKey: NSForegroundColorAttributeName];
+			[secondaryTextAttributes setValue: [NSColor alternateSelectedControlTextColor]
+									   forKey: NSForegroundColorAttributeName];
+		} else {
+			[mainTextAttributes setValue: [NSColor selectedTextColor]
+								  forKey: NSForegroundColorAttributeName];
+			[secondaryTextAttributes setValue: [NSColor selectedTextColor]
+									   forKey: NSForegroundColorAttributeName];
+		}
 	}
 	if ([self isHighlighted] && !current)
 	{
-		[mainTextAttributes setValue: [NSColor whiteColor]
+		[mainTextAttributes setValue: [NSColor controlTextColor]
 							  forKey: NSForegroundColorAttributeName];
-		[secondaryTextAttributes setValue: [NSColor whiteColor]
+		[secondaryTextAttributes setValue: [NSColor controlTextColor]
 								   forKey: NSForegroundColorAttributeName];
 	}
 


### PR DESCRIPTION
This PR allows Macfusion to look good on both light and dark appearance. 
A tricky part is to handle alternateSelectedControlTextColor in a text view in macOS 10.12+. I have tested it only on 10.14 but it should work for older versions too.